### PR TITLE
Bump version to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-bundle-calculator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-bundle-calculator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CLI for executing CQL calculation for a generated Synthea Patient Bundle",
   "repository": "git@github.com:projecttacoma/fhir-bundle-calculator.git",
   "author": "Matthew Gramigna <mgramigna@mitre.org>",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bin": {
     "calculate-bundles": "./src/cli.js"
   },
-  "license": "Apache",
+  "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.19.0",
     "commander": "^4.0.1",


### PR DESCRIPTION
Forgot to do this in #10.

New minor version. Also updated the license field in package.json (wasn't the valid [SPDX expression](https://spdx.org/licenses/))