### PR TITLE
Improve error reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
 node_modules
-test-bundles
 output
-synthea
-connectathon
-.cqf-ruler
-.seed-cqf-ruler
-.setup-cqf-ruler
-*.csv
+*.log

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Available options:
 Usage: calculate-bundles -d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd -m <measure-id>]
 
 Options:
-  -v --version                      Print the current version
-  -d --directory <input-directory>  Path to directory of Synthea Bundles
-  -c --cql <cql-file>               Path to cql file to be used for calculation
-  -m --measure-id <measure-id>      Measure ID to evaluate
-  -u --url <url>                    Base URL of running cqf-ruler instance (default: "http://localhost:8080/cqf-ruler-r4/fhir")
-  -s --period-start <yyyy-mm-dd>    Start of the calculation period (default: "2019-01-01")
-  -e --period-end <yyyy-mm-dd>      End of the calculation period (default: "2019-12-31")
-  -h, --help                        Output usage information
+  -v, --version                      print the current version
+  -d, --directory <input-directory>  path to directory of Synthea Bundles
+  -c, --cql <cql-file>               path to cql file to be used for calculation
+  -m, --measure-id <measure-id>      measure ID to evaluate
+  -u, --url <url>                    base URL of running cqf-ruler instance (default: "http://localhost:8080/cqf-ruler-r4/fhir")
+  -s, --period-start <yyyy-mm-dd>    start of the calculation period (default: "2019-01-01")
+  -e, --period-end <yyyy-mm-dd>      end of the calculation period (default: "2019-12-31")
+  -h, --help                         output usage information
 ```
 
 ## Local Usage

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Some initial logging is done for the CLI, but more verbose logging can  be done 
 
 Example:
 ``` bash
-DEBUG=true calculation-bundles [--options]
+DEBUG=true calculate-bundles [--options]
 ```
 
 The responses for each `$cql` call are written to a log file `cql-responses.log` in case of any need for manual inspection of the response body.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ calculate-bundles [--options]
 Available options:
 
 ```
-Usage: cli -d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd -m <measure-id>]
+Usage: calculate-bundles -d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd -m <measure-id>]
 
 Options:
   -v --version                      Print the current version
@@ -43,7 +43,7 @@ Options:
   -u --url <url>                    Base URL of running cqf-ruler instance (default: "http://localhost:8080/cqf-ruler-r4/fhir")
   -s --period-start <yyyy-mm-dd>    Start of the calculation period (default: "2019-01-01")
   -e --period-end <yyyy-mm-dd>      End of the calculation period (default: "2019-12-31")
-  -h, --help                        output usage information
+  -h, --help                        Output usage information
 ```
 
 ## Local Usage
@@ -104,7 +104,7 @@ In this case, the above output is mostly the same, but columns will be added tha
 
 ## Debugging
 
-Some initial logging is done for the CLI, but more verbose logging can  be done by setting `DEBUG=true` in the environment. 
+Some initial logging is done for the CLI, but more verbose logging can be done by setting `DEBUG=true` in the environment. 
 
 Example:
 ``` bash

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ A CLI for outputting population statistics for FHIR patients and executing CQL f
 npm install -g fhir-bundle-calculator
 ```
 
+Installation can be verified with the `--version` flag:
+
+```bash
+calculate-bundles --version
+X.Y.Z
+```
+
 Usage:
 
 ``` bash
@@ -26,16 +33,17 @@ calculate-bundles [--options]
 Available options:
 
 ```
-Usage: calculate-bundles -d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd]
+Usage: cli -d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd -m <measure-id>]
 
 Options:
+  -v --version                      Print the current version
   -d --directory <input-directory>  Path to directory of Synthea Bundles
   -c --cql <cql-file>               Path to cql file to be used for calculation
-  -u --url <url>                    Base URL of running cqf-ruler instance
+  -m --measure-id <measure-id>      Measure ID to evaluate
+  -u --url <url>                    Base URL of running cqf-ruler instance (default: "http://localhost:8080/cqf-ruler-r4/fhir")
   -s --period-start <yyyy-mm-dd>    Start of the calculation period (default: "2019-01-01")
   -e --period-end <yyyy-mm-dd>      End of the calculation period (default: "2019-12-31")
-  -v --verbose                      Enable debug logging (default: false)
-  -h, --help
+  -h, --help                        output usage information
 ```
 
 ## Local Usage
@@ -52,20 +60,7 @@ This will pull the source code and install the necessary dependencies. You can r
 node src/cli.js [--options]
 ```
 
-Available options:
-
-```
-Usage: cli -d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd]
-
-Options:
-  -d --directory <input-directory>  Path to directory of Synthea Bundles
-  -c --cql <cql-file>               Path to cql file to be used for calculation
-  -u --url <url>                    Base URL of running cqf-ruler instance
-  -s --period-start <yyyy-mm-dd>    Start of the calculation period (default: "2019-01-01")
-  -e --period-end <yyyy-mm-dd>      End of the calculation period (default: "2019-12-31")
-  -v --verbose                      Enable debug logging (default: false)
-  -h, --help                        output usage information
-```
+Options are the same as above.
 
 ## Output
 
@@ -74,8 +69,8 @@ The CLI will create a directory called `output`, and inside this directory will 
 * A file `results.csv` of the following format:
 
 ``` csv
-"bundle","initial_population","numerator","denominator","error"
-"<bundle-name>",<true or false>,<true or false>,<true or false>,an error message if an error happened
+"bundle","initial_population","numerator","denominator"
+"<bundle-name>",<true or false>,<true or false>,<true or false>
 ```
 
 * Subdirectories for each population, containing the bundles that fell into those populations. **NOTE**: This will not duplicate bundles. E.g. if a patient falls into the numerator, they will only appear in that directory since it is a subset of the other two. Similar reasoning applies to a patient falling into the denominator as it is a subset of the IPOP.
@@ -92,9 +87,6 @@ output
 │   ├── numerator
 │   │   ├── a-patient.bundle.json
 │   │   └── ...
-│   ├── errors
-│   │   ├── a-patient.bundle.json
-│   │   └── ...
 │   └── results.csv
 └──
 ```
@@ -106,9 +98,20 @@ The cli will be able to detect if the provided CQL represents an Episode of Care
 In this case, the above output is mostly the same, but columns will be added that correspond to the number of episodes that fell into the relevant populations for the patient bundle in question, as well as a list of IDs for the episode:
 
 ``` csv
-"bundle","initial_population","numerator","denominator","initial_population_episodes","initial_population_episodeIds","denominator_episodes","denominator_episodeIds","numerator_episodes","numerator_episodeIds","error"
-"<bundle-name>",<true or false>,<true or false>,<true or false>,<count>,<list>,<count>,<list>,<count>,<list>,an error message if an error happened
+"bundle","initial_population","numerator","denominator","initial_population_episodes","initial_population_episodeIds","denominator_episodes","denominator_episodeIds","numerator_episodes","numerator_episodeIds"
+"<bundle-name>",<true or false>,<true or false>,<true or false>,<count>,<list>,<count>,<list>,<count>,<list>
 ```
+
+## Debugging
+
+Some initial logging is done for the CLI, but more verbose logging can  be done by setting `DEBUG=true` in the environment. 
+
+Example:
+``` bash
+DEBUG=true calculation-bundles [--options]
+```
+
+The responses for each `$cql` call are written to a log file `cql-responses.log` in case of any need for manual inspection of the response body.
 
 ## Unit Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-bundle-calculator",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-bundle-calculator",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "CLI for executing CQL calculation for a generated Synthea Patient Bundle",
   "repository": "git@github.com:projecttacoma/fhir-bundle-calculator.git",
   "author": "Matthew Gramigna <mgramigna@mitre.org>",

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,13 +19,13 @@ const { logger } = require('./utils/logger');
 const { calculate } = require('./utils/calculation');
 
 program
-  .version('2.0.0', '-v --version', 'Print the current version')
-  .option('-d --directory <input-directory>', 'Path to directory of Synthea Bundles')
-  .option('-c --cql <cql-file>', 'Path to cql file to be used for calculation')
-  .option('-m --measure-id <measure-id>', 'Measure ID to evaluate')
-  .option('-u --url <url>', 'Base URL of running cqf-ruler instance', 'http://localhost:8080/cqf-ruler-r4/fhir')
-  .option('-s --period-start <yyyy-mm-dd>', 'Start of the calculation period', '2019-01-01')
-  .option('-e --period-end <yyyy-mm-dd>', 'End of the calculation period', '2019-12-31')
+  .version('2.0.0', '-v, --version', 'print the current version')
+  .option('-d, --directory <input-directory>', 'path to directory of Synthea Bundles')
+  .option('-c, --cql <cql-file>', 'path to cql file to be used for calculation')
+  .option('-m, --measure-id <measure-id>', 'measure ID to evaluate')
+  .option('-u, --url <url>', 'base URL of running cqf-ruler instance', 'http://localhost:8080/cqf-ruler-r4/fhir')
+  .option('-s, --period-start <yyyy-mm-dd>', 'start of the calculation period', '2019-01-01')
+  .option('-e, --period-end <yyyy-mm-dd>', 'end of the calculation period', '2019-12-31')
   .usage('-d /path/to/bundles -c /path/to/cql/file -u http://<cqf-ruler-base-url> [-s yyyy-mm-dd -e yyyy-mm-dd -m <measure-id>]')
   .parse(process.argv);
 

--- a/src/utils/calculation.js
+++ b/src/utils/calculation.js
@@ -49,7 +49,6 @@ const calculate = async (url, cql, patientId, periodStart, periodEnd) => {
   const parameters = buildParameters(cql, patientId, periodStart, periodEnd);
   const response = await axios.post(`${url}/$cql`, parameters);
 
-  // Log cql response to a file
   logger.debug('Logging $cql response to cql-responses.log');
   fileLogger.info(response.data);
 

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,12 @@
+const { logger } = require('./logger');
+
+exports.handleHttpError = (err) => {
+  if (err.response) {
+    logger.debug('Got response from server, but bad status code');
+    logger.error(`${err.message}: ${JSON.stringify(err.response.data)}`);
+  } else {
+    logger.debug('Got no response from server');
+    logger.error(err.message);
+  }
+  process.exit(1);
+};

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,28 @@
+const { loggers, format, transports } = require('winston');
+
+const fileTransport = new transports.File({ filename: 'cql-response.log' });
+
+if (!loggers.has('cli')) {
+  loggers.add('cli', {
+    level: process.env.DEBUG ? 'debug' : 'info',
+    format: format.cli(),
+    transports: [
+      new transports.Console(),
+    ],
+  });
+}
+
+if (!loggers.has('file')) {
+  loggers.add('file', {
+    level: process.env.DEBUG ? 'debug' : 'info',
+    format: format.json(),
+    transports: [
+      fileTransport,
+    ],
+  });
+}
+
+module.exports = {
+  logger: loggers.get('cli'),
+  fileLogger: loggers.get('file'),
+};

--- a/test/fixtures/all-populations-response.json
+++ b/test/fixtures/all-populations-response.json
@@ -1,0 +1,69 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "Initial Population",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Initial Population",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[1:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "true"
+          },
+          {
+            "name": "resultType",
+            "valueString": "Boolean"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "Numerator",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Numerator",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[4:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "true"
+          },
+          {
+            "name": "resultType",
+            "valueString": "Boolean"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "Denominator",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Denominator",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[7:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "true"
+          },
+          {
+            "name": "resultType",
+            "valueString": "Boolean"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/episode-of-care-response.json
+++ b/test/fixtures/episode-of-care-response.json
@@ -1,0 +1,104 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "Initial Population",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Initial Population",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[66:1]"
+          },
+          {
+            "name": "value",
+            "resource": {
+              "resourceType": "Bundle",
+              "type": "collection",
+              "entry": [
+                {
+                  "resourceType": "Encounter",
+                  "resource": {
+                    "id": 0
+                  }
+                },
+                {
+                  "resourceType": "Encounter",
+                  "resource": {
+                    "id": 1
+                  }
+                },
+                {
+                  "resourceType": "Encounter",
+                  "resource": {
+                    "id": 2
+                  }
+                },
+                {
+                  "resourceType": "Encounter",
+                  "resource": {
+                    "id": 3
+                  }
+                },
+                {
+                  "resourceType": "Encounter",
+                  "resource": {
+                    "id": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "resultType",
+            "valueString": "List"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "Denominator",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Denominator",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[85:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "[]"
+          },
+          {
+            "name": "resultType",
+            "valueString": "List"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "Numerator",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Numerator",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[118:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "[]"
+          },
+          {
+            "name": "resultType",
+            "valueString": "List"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/error-response.json
+++ b/test/fixtures/error-response.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "Initial Population",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Error",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[1:0]"
+          },
+          {
+            "name": "error",
+            "valueString": "Syntax error at this"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/some-populations-response.json
+++ b/test/fixtures/some-populations-response.json
@@ -1,0 +1,69 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "Initial Population",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Initial Population",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[1:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "true"
+          },
+          {
+            "name": "resultType",
+            "valueString": "Boolean"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "Numerator",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Numerator",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[4:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "false"
+          },
+          {
+            "name": "resultType",
+            "valueString": "Boolean"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "Denominator",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Denominator",
+        "parameter": [
+          {
+            "name": "location",
+            "valueString": "[7:1]"
+          },
+          {
+            "name": "value",
+            "valueString": "true"
+          },
+          {
+            "name": "resultType",
+            "valueString": "Boolean"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

This PR updates the CLI to have more verbose error reporting to the console, as well as failing when any error is encountered (Promise rejection, cql error, regular javascript error, etc.)

Addresses #12 by adding a version flag

Technically, this breaks backwards compatibility due to the deprecation of the `--verbose` flag and the addition of `DEBUG=true` to the command, so I have bumped the semantic version to `2.0.0`

## New behavior

Most of the new behavior takes place in the form of logging behavior. Logger errors are now more useful, as well as the presence of `cql-responses.log` to show the json output for each call.

## Code changes

Lots.

* Added `src/utils/errors.js` as a common util for error handling. Currently just has a function for handling http errors from cqf ruler 
* Added `src/utils/logger.js` as a common logger for all pieces of the code to use
  * Currently supports logging to console or logging JSON objects to a file
* Added various `process.exit(1)`s when errors are countered to halt execution of the program when errors occur
  * This will be useful for detecting failures in a CI context in the future
  * Consequently, removed the `error` column from the CSV output and such, as the program will now exit when errors are occurred, so it won't even reach the CSV generation stage if there is an error.
* Updated unit tests to have mocked json responses in separate files: easier to modify in the long run if need be
* Updated README to include information about debugging and logs.

# Testing guidance

You can test by either running the code from source by pulling this down and running `node src/cli.js --options` or use `npm link` and run `calculate-bundles` as you usually would. These are a few cases that I tested when trying to encounter different errors. Definitely do these, and maybe try any others that I didn't think of:

* Test correct execution of the program against a properly loaded cqf-ruler server
* Test error scenario where the cqf-ruler endpoint is incorrect
* Test CQL errors: try testing on a cqf-ruler that has no valuesets or something
* Test incorrect measure id (e.g. `-m matt-is-cool`)
  * This has happened before in our `Makefiles` so the error should be properly reported as a 404 from cqf-ruler rather than just log "Error generating measure report" 

There could be other error cases not mentioned, but I recommend starting with the above. Godspeed.
