### PR TITLE
Version fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A CLI for outputting population statistics and MeasureReports for FHIR patients 
 
 ## Prerequisites
 
-* [Node.js](https://nodejs.org/en/)
+* [Node.js >=10.15.1](https://nodejs.org/en/)
 * A running `cqf-ruler` server. See their [usage instructions](https://github.com/DBCG/cqf-ruler#usage) or use a public sandbox
 
 ## Installation with NPM

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-bundle-calculator",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "eslint-plugin-import": "^2.18.2",
     "jest": "^24.9.0",
     "nock": "^11.7.0"
+  },
+  "engines": {
+    "node": ">=10.15.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-bundle-calculator",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A CLI for outputting population statistics and MeasureReports for FHIR patients for an eCQM using the $evaluate-measure operation",
   "repository": "git@github.com:projecttacoma/fhir-bundle-calculator.git",
   "author": "Matthew Gramigna <mgramigna@mitre.org>",

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,7 +19,7 @@ const { logger } = require('./utils/logger');
 const { getCalculationResults } = require('./utils/calculation');
 
 program
-  .version('3.0.0', '-v, --version', 'print the current version')
+  .version('3.0.3', '-v, --version', 'print the current version')
   .option('-d, --directory <input-directory>', 'path to directory of Synthea Bundles')
   .option('-m, --measure-id <measure-id>', 'measure ID to evaluate')
   .option('-u, --url <url>', 'base URL of running cqf-ruler instance', 'http://localhost:8080/cqf-ruler-r4/fhir')


### PR DESCRIPTION
# Summary

Found an issue where the call to `fs.mkdirSync` with the `recursive` flag would not work on lower versions of node. This was fixed in node `10.15.1`, so I added a note for that in `package.json` using the [engines](https://docs.npmjs.com/files/package.json#engines) property.

## New behavior

N/A

## Code changes

Versioning all around

# Testing guidance

N/A. Just visual
